### PR TITLE
Add run-export on itself

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -30,7 +30,7 @@ requirements:
   host:
     - brotli
   run_exports:
-      - ${{ pin_subpackage('libzlib', exact=True) }}
+      - ${{ pin_subpackage('woff2', exact=True) }}
 
 tests:
   - package_contents:


### PR DESCRIPTION
Since woff2 provides a shared library it needs to have a run export on itself so that the shared library is then also available during runtime


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
